### PR TITLE
Updates

### DIFF
--- a/app/cash/index.tsx
+++ b/app/cash/index.tsx
@@ -23,7 +23,7 @@ function Cash(props: Props): JSXElement {
 
     createEffect(() => setDate(end()));
 
-    return <div id="cash" class={styles.cash} on:selectDate={({ detail: date }) => setDate(date)}>
+    return <div class={styles.cash} on:selectDate={({ detail: date }) => setDate(date)}>
         <div class={styles.stats}>
             <h2>Cash Index</h2>
 

--- a/app/cutout/index.tsx
+++ b/app/cutout/index.tsx
@@ -26,7 +26,7 @@ function Cutout(props: Props): JSXElement {
 
     createEffect(() => setDate(end()));
 
-    return <div id="cutout" class={styles.cutout} on:selectDate={({ detail: date }) => setDate(date)}>
+    return <div class={styles.cutout} on:selectDate={({ detail: date }) => setDate(date)}>
         <div class={styles.stats}>
             <Index each={stats()}>
                 { (stat, index) =>

--- a/app/primal/index.tsx
+++ b/app/primal/index.tsx
@@ -31,7 +31,7 @@ function Primal(props: Props): JSXElement {
 
     createEffect(() => setDate(end()));
 
-    return <div id="primals" class={styles.primal} on:selectDate={({ detail: date }) => setDate(date)}>
+    return <div class={styles.primal} on:selectDate={({ detail: date }) => setDate(date)}>
         <div class={styles.stats}>
             <Index each={stats()}>
                 { (stat, index) =>

--- a/app/purchases/index.tsx
+++ b/app/purchases/index.tsx
@@ -13,8 +13,8 @@ interface Props {
 }
 
 const series = (purchases: Purchase[]): Data[][] => [
-    purchases.filter(record => record.arrangement === Arrangement.MarketFormula && !Number.isNaN(record.avgPrice))
-        .map(record => ({ date: record.date, reportDate: record.reportDate, value: record.avgPrice }))
+    purchases.filter(record => record.arrangement === Arrangement.MarketFormula && record.avgPrice != null)
+        .map(record => ({ date: record.date, reportDate: record.reportDate, value: record.avgPrice })) as Data[]
 ];
 
 const labels = ["Formula", "Negotiated"];
@@ -27,7 +27,7 @@ function Purchases(props: Props): JSXElement {
 
     createEffect(() => setDate(end()));
 
-    return <div id="purchases" class={styles.purchases} on:selectDate={({ detail: date }) => setDate(date)}>
+    return <div class={styles.purchases} on:selectDate={({ detail: date }) => setDate(date)}>
         <div class={styles.stats}>
             <Index each={stats()}>
                 { (stat, index) =>

--- a/app/timepicker/index.tsx
+++ b/app/timepicker/index.tsx
@@ -12,14 +12,14 @@ interface Props {
 }
 
 function TimePicker(props: Props): JSXElement {
-    return <div id="timepicker">
+    return <>
         <div class={styles.period}>
             <PeriodSelector selected={props.period} />
         </div>
         <div class={styles.datepicker}>
             <DateSlider start={props.start} end={props.end} date={props.date} />
         </div>
-    </div>;
+    </>;
 }
 
 export default TimePicker;

--- a/test/features/timepicker/period.selector.spec.ts
+++ b/test/features/timepicker/period.selector.spec.ts
@@ -3,48 +3,49 @@ import { Given, Then, When } from "@badeball/cypress-cucumber-preprocessor";
 Given("I'm on the app", () => {
     cy.visit("/");
     cy.title().should("eq", "Mpr Dashboard");
+    cy.get("#app").should("exist");
 });
 
 Given(/^the (.*) button is not selected$/, (button: string) => {
-    cy.get("#timepicker").find("span").not(`:contains(${button})`).first().click();
+    cy.get("div[class*=timepicker]").find("span").not(`:contains(${button})`).first().click();
 });
 
 When(/^I click the (.*) button$/, (button: string) => {
-    cy.get("#timepicker").contains("span", button).click();
+    cy.get("div[class*=timepicker]").contains("span", button).click();
 });
 
 Then(/^(.*) is highlighted$/, (button: string) => {
-    cy.get("#timepicker").find("span[class*=active]").contains(button).should("exist");
+    cy.get("div[class*=timepicker]").find("span[class*=active]").contains(button).should("exist");
 });
 
 Then("I see one month of data on each chart", () => {
-    cy.get("#cash path.series").invoke("attr", "d").its("length").should("eq", 417);
-    cy.get("#cutout path.series").first().invoke("attr", "d").its("length").should("eq", 373);
-    cy.get("#cutout path.series").last().invoke("attr", "d").its("length").should("eq", 381);
-    cy.get("#purchases path.series").invoke("attr", "d").its("length").should("eq", 419);
-    cy.get("#primals path.series").invoke("attr", "d").its("length").should("eq", 433);
+    cy.get("div[class*=cash] path.series").invoke("attr", "d").its("length").should("eq", 417);
+    cy.get("div[class*=cutout] path.series").first().invoke("attr", "d").its("length").should("eq", 373);
+    cy.get("div[class*=cutout] path.series").last().invoke("attr", "d").its("length").should("eq", 381);
+    cy.get("div[class*=purchases] path.series").invoke("attr", "d").its("length").should("eq", 419);
+    cy.get("div[class*=primal] path.series").invoke("attr", "d").its("length").should("eq", 433);
 });
 
 Then("I see three months of data on each chart", () => {
-    cy.get("#cash path.series").invoke("attr", "d").its("length").should("eq", 1093);
-    cy.get("#cutout path.series").first().invoke("attr", "d").its("length").should("eq", 1073);
-    cy.get("#cutout path.series").last().invoke("attr", "d").its("length").should("eq", 1075);
-    cy.get("#purchases path.series").invoke("attr", "d").its("length").should("eq", 1091);
-    cy.get("#primals path.series").invoke("attr", "d").its("length").should("eq", 1115);
+    cy.get("div[class*=cash] path.series").invoke("attr", "d").its("length").should("eq", 1093);
+    cy.get("div[class*=cutout] path.series").first().invoke("attr", "d").its("length").should("eq", 1073);
+    cy.get("div[class*=cutout] path.series").last().invoke("attr", "d").its("length").should("eq", 1075);
+    cy.get("div[class*=purchases] path.series").invoke("attr", "d").its("length").should("eq", 1091);
+    cy.get("div[class*=primal] path.series").invoke("attr", "d").its("length").should("eq", 1115);
 });
 
 Then("I see six months of data on each chart", () => {
-    cy.get("#cash path.series").invoke("attr", "d").its("length").should("eq", 2073);
-    cy.get("#cutout path.series").first().invoke("attr", "d").its("length").should("eq", 2021);
-    cy.get("#cutout path.series").last().invoke("attr", "d").its("length").should("eq", 2021);
-    cy.get("#purchases path.series").invoke("attr", "d").its("length").should("eq", 2105);
-    cy.get("#primals path.series").invoke("attr", "d").its("length").should("eq", 2095);
+    cy.get("div[class*=cash] path.series").invoke("attr", "d").its("length").should("eq", 2073);
+    cy.get("div[class*=cutout] path.series").first().invoke("attr", "d").its("length").should("eq", 2021);
+    cy.get("div[class*=cutout] path.series").last().invoke("attr", "d").its("length").should("eq", 2021);
+    cy.get("div[class*=purchases] path.series").invoke("attr", "d").its("length").should("eq", 2105);
+    cy.get("div[class*=primal] path.series").invoke("attr", "d").its("length").should("eq", 2095);
 });
 
 Then("I see one year of data on each chart", () => {
-    cy.get("#cash path.series").invoke("attr", "d").its("length").should("eq", 3971);
-    cy.get("#cutout path.series").first().invoke("attr", "d").its("length").should("eq", 3973);
-    cy.get("#cutout path.series").last().invoke("attr", "d").its("length").should("eq", 3977);
-    cy.get("#purchases path.series").invoke("attr", "d").its("length").should("eq", 3989);
-    cy.get("#primals path.series").invoke("attr", "d").its("length").should("eq", 4053);
+    cy.get("div[class*=cash] path.series").invoke("attr", "d").its("length").should("eq", 3971);
+    cy.get("div[class*=cutout] path.series").first().invoke("attr", "d").its("length").should("eq", 3973);
+    cy.get("div[class*=cutout] path.series").last().invoke("attr", "d").its("length").should("eq", 3977);
+    cy.get("div[class*=purchases] path.series").invoke("attr", "d").its("length").should("eq", 3989);
+    cy.get("div[class*=primal] path.series").invoke("attr", "d").its("length").should("eq", 4053);
 });

--- a/test/features/timepicker/period.selector.spec.ts
+++ b/test/features/timepicker/period.selector.spec.ts
@@ -5,15 +5,15 @@ Given("I'm on the app", () => {
     cy.title().should("eq", "Mpr Dashboard");
 });
 
-Given(/the (.*) button is not selected/, (button: string) => {
+Given(/^the (.*) button is not selected$/, (button: string) => {
     cy.get("#timepicker").find("span").not(`:contains(${button})`).first().click();
 });
 
-When(/I click the (.*) button/, (button: string) => {
+When(/^I click the (.*) button$/, (button: string) => {
     cy.get("#timepicker").contains("span", button).click();
 });
 
-Then(/(.*) is highlighted/, (button: string) => {
+Then(/^(.*) is highlighted$/, (button: string) => {
     cy.get("#timepicker").find("span[class*=active]").contains(button).should("exist");
 });
 

--- a/test/features/tsconfig.json
+++ b/test/features/tsconfig.json
@@ -3,7 +3,7 @@
     "compilerOptions": {
         "target": "es5",
         "lib": ["es5", "es2015", "dom"],
-        "types": ["cypress"],
+        "types": ["cypress", "node"],
         "esModuleInterop": true,
         "module": "Node16",
         "moduleResolution": "node16"

--- a/test/package.json
+++ b/test/package.json
@@ -19,11 +19,13 @@
         "@types/command-line-args": "^5.2.1",
         "@types/cypress": "^1.1.3",
         "@types/node": "^20.8.2",
-        "@types/resolve": "^1.20.3"
+        "@types/resolve": "^1.20.3",
+        "@types/testing-library__cypress": "^5.0.10"
     },
     "dependencies": {
         "@badeball/cypress-cucumber-preprocessor": "^18.0.6",
         "@bahmutov/cypress-esbuild-preprocessor": "^2.2.0",
+        "@testing-library/cypress": "^10.0.1",
         "@vitest/coverage-istanbul": "^0.34.6",
         "cypress": "^13.3.0",
         "esbuild": "^0.19.4",

--- a/test/smoke/smoke.spec.ts
+++ b/test/smoke/smoke.spec.ts
@@ -1,6 +1,6 @@
 import "@testing-library/cypress/add-commands";
 
-it("loads", function() {
+it("loads data from the api and renders charts and stats", function() {
     const value = /\d{2,3}\.\d{2}/;
 
     // Page load

--- a/test/smoke/smoke.spec.ts
+++ b/test/smoke/smoke.spec.ts
@@ -6,23 +6,23 @@ describe("The app loads", function() {
     });
 
     it("should display the app", () => {
-        cy.get("#app").its("length").should("eq", 1);
+        cy.get("#app").should("exist");
     });
 
     it("should display the cash index chart", () => {
-        cy.get("#cash path.series").invoke("attr", "d").its("length").should("greaterThan", 0);
+        cy.get("#cash path.series").invoke("attr", "d").its("length").should("be.greaterThan", 100);
     });
 
     it("should display the cutout chart", () => {
-        cy.get("#cutout path.series").first().invoke("attr", "d").its("length").should("greaterThan", 0);
-        cy.get("#cutout path.series").last().invoke("attr", "d").its("length").should("greaterThan", 0);
+        cy.get("#cutout path.series").first().invoke("attr", "d").its("length").should("be.greaterThan", 100);
+        cy.get("#cutout path.series").last().invoke("attr", "d").its("length").should("be.greaterThan", 100);
     });
 
     it("should display the purchases chart", () => {
-        cy.get("#purchases path.series").invoke("attr", "d").its("length").should("greaterThan", 0);
+        cy.get("#purchases path.series").invoke("attr", "d").its("length").should("be.greaterThan", 100);
     });
 
     it("should display the primals chart", () => {
-        cy.get("#primals path.series").invoke("attr", "d").its("length").should("greaterThan", 0);
+        cy.get("#primals path.series").invoke("attr", "d").its("length").should("be.greaterThan", 100);
     });
 });

--- a/test/smoke/smoke.spec.ts
+++ b/test/smoke/smoke.spec.ts
@@ -1,19 +1,24 @@
+import "@testing-library/cypress/add-commands";
+
 it("loads", function() {
+    const value = /\d{2,3}\.\d{2}/;
+
+    // Page load
     cy.visit("/");
     cy.title().should("eq", "Mpr Dashboard");
     cy.get("#app").should("exist");
 
     // Stats
-    cy.get("div[class*=cash]").find("h2[class*=value]").contains(/\d{2,3}\.\d{2}/);
-    cy.get("div[class*=cutout]").find("h5[class*=label]").contains("Cutout").find("+h3").contains(/\d{2,3}\.\d{2}/);
-    cy.get("div[class*=cutout]").find("h5[class*=label]").contains("Index").find("+h3").contains(/\d{2,3}\.\d{2}/);
-    cy.get("div[class*=purchases]").find("h5[class*=label]").contains("Formula").find("+h3").contains(/\d{2,3}\.\d{2}/);
-    cy.get("div[class*=primal]").find("h5[class*=label]").contains("Belly").find("+h3").contains(/\d{2,3}\.\d{2}/);
-    cy.get("div[class*=primal]").find("h5[class*=label]").contains("Ham").find("+h3").contains(/\d{2,3}\.\d{2}/);
-    cy.get("div[class*=primal]").find("h5[class*=label]").contains("Loin").find("+h3").contains(/\d{2,3}\.\d{2}/);
-    cy.get("div[class*=primal]").find("h5[class*=label]").contains("Butt").find("+h3").contains(/\d{2,3}\.\d{2}/);
-    cy.get("div[class*=primal]").find("h5[class*=label]").contains("Rib").find("+h3").contains(/\d{2,3}\.\d{2}/);
-    cy.get("div[class*=primal]").find("h5[class*=label]").contains("Picnic").find("+h3").contains(/\d{2,3}\.\d{2}/);
+    cy.findByText("Cash Index").siblings().contains(value).should("exist");
+    cy.findByText("Cutout").siblings().contains(value).should("exist");
+    cy.findByText("Index").siblings().contains(value).should("exist");
+    cy.findByText("Formula").siblings().contains(value).should("exist");
+    cy.findByText("Belly").siblings().contains(value).should("exist");
+    cy.findByText("Ham").siblings().contains(value).should("exist");
+    cy.findByText("Loin").siblings().contains(value).should("exist");
+    cy.findByText("Butt").siblings().contains(value).should("exist");
+    cy.findByText("Rib").siblings().contains(value).should("exist");
+    cy.findByText("Picnic").siblings().contains(value).should("exist");
 
     // Charts
     cy.get("div[class*=cash] path.series").invoke("attr", "d").its("length").should("be.greaterThan", 100);

--- a/test/smoke/smoke.spec.ts
+++ b/test/smoke/smoke.spec.ts
@@ -1,28 +1,24 @@
-describe("The app loads", function() {
-    beforeEach(() => cy.visit("/"));
+it("loads", function() {
+    cy.visit("/");
+    cy.title().should("eq", "Mpr Dashboard");
+    cy.get("#app").should("exist");
 
-    it("should show the title", () => {
-        cy.title().should("eq", "Mpr Dashboard");
-    });
+    // Stats
+    cy.get("div[class*=cash]").find("h2[class*=value]").contains(/\d{2,3}\.\d{2}/);
+    cy.get("div[class*=cutout]").find("h5[class*=label]").contains("Cutout").find("+h3").contains(/\d{2,3}\.\d{2}/);
+    cy.get("div[class*=cutout]").find("h5[class*=label]").contains("Index").find("+h3").contains(/\d{2,3}\.\d{2}/);
+    cy.get("div[class*=purchases]").find("h5[class*=label]").contains("Formula").find("+h3").contains(/\d{2,3}\.\d{2}/);
+    cy.get("div[class*=primal]").find("h5[class*=label]").contains("Belly").find("+h3").contains(/\d{2,3}\.\d{2}/);
+    cy.get("div[class*=primal]").find("h5[class*=label]").contains("Ham").find("+h3").contains(/\d{2,3}\.\d{2}/);
+    cy.get("div[class*=primal]").find("h5[class*=label]").contains("Loin").find("+h3").contains(/\d{2,3}\.\d{2}/);
+    cy.get("div[class*=primal]").find("h5[class*=label]").contains("Butt").find("+h3").contains(/\d{2,3}\.\d{2}/);
+    cy.get("div[class*=primal]").find("h5[class*=label]").contains("Rib").find("+h3").contains(/\d{2,3}\.\d{2}/);
+    cy.get("div[class*=primal]").find("h5[class*=label]").contains("Picnic").find("+h3").contains(/\d{2,3}\.\d{2}/);
 
-    it("should display the app", () => {
-        cy.get("#app").should("exist");
-    });
-
-    it("should display the cash index chart", () => {
-        cy.get("div[class*=cash] path.series").invoke("attr", "d").its("length").should("be.greaterThan", 100);
-    });
-
-    it("should display the cutout chart", () => {
-        cy.get("div[class*=cutout] path.series").first().invoke("attr", "d").its("length").should("be.greaterThan", 100);
-        cy.get("div[class*=cutout] path.series").last().invoke("attr", "d").its("length").should("be.greaterThan", 100);
-    });
-
-    it("should display the purchases chart", () => {
-        cy.get("div[class*=purchases] path.series").invoke("attr", "d").its("length").should("be.greaterThan", 100);
-    });
-
-    it("should display the primals chart", () => {
-        cy.get("div[class*=primal] path.series").invoke("attr", "d").its("length").should("be.greaterThan", 100);
-    });
+    // Charts
+    cy.get("div[class*=cash] path.series").invoke("attr", "d").its("length").should("be.greaterThan", 100);
+    cy.get("div[class*=cutout] path.series").first().invoke("attr", "d").its("length").should("be.greaterThan", 100);
+    cy.get("div[class*=cutout] path.series").last().invoke("attr", "d").its("length").should("be.greaterThan", 100);
+    cy.get("div[class*=purchases] path.series").invoke("attr", "d").its("length").should("be.greaterThan", 100);
+    cy.get("div[class*=primal] path.series").invoke("attr", "d").its("length").should("be.greaterThan", 100);
 });

--- a/test/smoke/smoke.spec.ts
+++ b/test/smoke/smoke.spec.ts
@@ -10,19 +10,19 @@ describe("The app loads", function() {
     });
 
     it("should display the cash index chart", () => {
-        cy.get("#cash path.series").invoke("attr", "d").its("length").should("be.greaterThan", 100);
+        cy.get("div[class*=cash] path.series").invoke("attr", "d").its("length").should("be.greaterThan", 100);
     });
 
     it("should display the cutout chart", () => {
-        cy.get("#cutout path.series").first().invoke("attr", "d").its("length").should("be.greaterThan", 100);
-        cy.get("#cutout path.series").last().invoke("attr", "d").its("length").should("be.greaterThan", 100);
+        cy.get("div[class*=cutout] path.series").first().invoke("attr", "d").its("length").should("be.greaterThan", 100);
+        cy.get("div[class*=cutout] path.series").last().invoke("attr", "d").its("length").should("be.greaterThan", 100);
     });
 
     it("should display the purchases chart", () => {
-        cy.get("#purchases path.series").invoke("attr", "d").its("length").should("be.greaterThan", 100);
+        cy.get("div[class*=purchases] path.series").invoke("attr", "d").its("length").should("be.greaterThan", 100);
     });
 
     it("should display the primals chart", () => {
-        cy.get("#primals path.series").invoke("attr", "d").its("length").should("be.greaterThan", 100);
+        cy.get("div[class*=primal] path.series").invoke("attr", "d").its("length").should("be.greaterThan", 100);
     });
 });

--- a/test/smoke/tsconfig.json
+++ b/test/smoke/tsconfig.json
@@ -4,9 +4,6 @@
         "target": "es5",
         "lib": ["es5", "es2015", "dom"],
         "types": ["cypress", "node"],
-        "esModuleInterop": true,
-        "module": "Node16",
-        "moduleResolution": "node16",
         "sourceMap": false
     },
     "include": ["**/*.ts"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,7 +29,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.22.13":
+"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.22.13":
   version: 7.22.13
   resolution: "@babel/code-frame@npm:7.22.13"
   dependencies:
@@ -439,6 +439,25 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 02ac4d5c812a52357c8f517f81584725f06f385d54ccfda89dd082e0ed89a94bd9f4d9b05fa1cbdcf426e3489c1921f04c93c5acc5deea83407a64c22ad2feb4
+  languageName: node
+  linkType: hard
+
+"@babel/runtime-corejs3@npm:^7.10.2":
+  version: 7.23.1
+  resolution: "@babel/runtime-corejs3@npm:7.23.1"
+  dependencies:
+    core-js-pure: ^3.30.2
+    regenerator-runtime: ^0.14.0
+  checksum: 5d52b0cc8b5d243e67cf29c584d15acdc0c89b64de4a3fe1cb8a83b84b64a5621802e36931f93ca696cb637884abd11c8514615d890a4edf057ec4464f73915d
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.6":
+  version: 7.23.1
+  resolution: "@babel/runtime@npm:7.23.1"
+  dependencies:
+    regenerator-runtime: ^0.14.0
+  checksum: 0cd0d43e6e7dc7f9152fda8c8312b08321cda2f56ef53d6c22ebdd773abdc6f5d0a69008de90aa41908d00e2c1facb24715ff121274e689305c858355ff02c70
   languageName: node
   linkType: hard
 
@@ -1425,6 +1444,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/types@npm:^26.6.2":
+  version: 26.6.2
+  resolution: "@jest/types@npm:26.6.2"
+  dependencies:
+    "@types/istanbul-lib-coverage": ^2.0.0
+    "@types/istanbul-reports": ^3.0.0
+    "@types/node": "*"
+    "@types/yargs": ^15.0.0
+    chalk: ^4.0.0
+  checksum: a0bd3d2f22f26ddb23f41fddf6e6a30bf4fab2ce79ec1cb6ce6fdfaf90a72e00f4c71da91ec61e13db3b10c41de22cf49d07c57ff2b59171d64b29f909c1d8d6
+  languageName: node
+  linkType: hard
+
 "@jridgewell/gen-mapping@npm:^0.3.0, @jridgewell/gen-mapping@npm:^0.3.2":
   version: 0.3.3
   resolution: "@jridgewell/gen-mapping@npm:0.3.3"
@@ -1541,6 +1573,50 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/cypress@npm:^10.0.1":
+  version: 10.0.1
+  resolution: "@testing-library/cypress@npm:10.0.1"
+  dependencies:
+    "@babel/runtime": ^7.14.6
+    "@testing-library/dom": ^9.0.0
+  peerDependencies:
+    cypress: ^12.0.0 || ^13.0.0
+  checksum: 737e16563844851e830786da1862ea2c29d9f67155d8d2ea4d5178c98b77621c67c89e47a91a633d36c0528adfff9592f7228a5f19666af9882c837eeacbd08e
+  languageName: node
+  linkType: hard
+
+"@testing-library/dom@npm:^7.11.0":
+  version: 7.31.2
+  resolution: "@testing-library/dom@npm:7.31.2"
+  dependencies:
+    "@babel/code-frame": ^7.10.4
+    "@babel/runtime": ^7.12.5
+    "@types/aria-query": ^4.2.0
+    aria-query: ^4.2.2
+    chalk: ^4.1.0
+    dom-accessibility-api: ^0.5.6
+    lz-string: ^1.4.4
+    pretty-format: ^26.6.2
+  checksum: 54fbedd1ecdfe1d47be2e592b98d18b2ab9d7e731f57231caf9b152593fe7329fe5ebe219e0e5d1e0df5b1ab803121cb8acd8b73bd1fb292bfdc2c55663eb01d
+  languageName: node
+  linkType: hard
+
+"@testing-library/dom@npm:^9.0.0":
+  version: 9.3.3
+  resolution: "@testing-library/dom@npm:9.3.3"
+  dependencies:
+    "@babel/code-frame": ^7.10.4
+    "@babel/runtime": ^7.12.5
+    "@types/aria-query": ^5.0.1
+    aria-query: 5.1.3
+    chalk: ^4.1.0
+    dom-accessibility-api: ^0.5.9
+    lz-string: ^1.5.0
+    pretty-format: ^27.0.2
+  checksum: 34e0a564da7beb92aa9cc44a9080221e2412b1a132eb37be3d513fe6c58027674868deb9f86195756d98d15ba969a30fe00632a4e26e25df2a5a4f6ac0686e37
+  languageName: node
+  linkType: hard
+
 "@tootallnate/once@npm:2":
   version: 2.0.0
   resolution: "@tootallnate/once@npm:2.0.0"
@@ -1573,6 +1649,20 @@ __metadata:
   version: 1.0.4
   resolution: "@tsconfig/node16@npm:1.0.4"
   checksum: 202319785901f942a6e1e476b872d421baec20cf09f4b266a1854060efbf78cde16a4d256e8bc949d31e6cd9a90f1e8ef8fb06af96a65e98338a2b6b0de0a0ff
+  languageName: node
+  linkType: hard
+
+"@types/aria-query@npm:^4.2.0":
+  version: 4.2.2
+  resolution: "@types/aria-query@npm:4.2.2"
+  checksum: 6f2ce11d91e2d665f3873258db19da752d91d85d3679eb5efcdf9c711d14492287e1e4eb52613b28e60375841a9e428594e745b68436c963d8bad4bf72188df3
+  languageName: node
+  linkType: hard
+
+"@types/aria-query@npm:^5.0.1":
+  version: 5.0.2
+  resolution: "@types/aria-query@npm:5.0.2"
+  checksum: 19394fea016e72da39dd5ef1cf1643e3252b7ee99d8f0b3a8740d3b72f874443fc1e00a41935b36fdfaf92cd735d4ae10dc5d6ab8f1192527d4c0471bb8ff8e4
   languageName: node
   linkType: hard
 
@@ -1736,6 +1826,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.0":
+  version: 2.0.4
+  resolution: "@types/istanbul-lib-coverage@npm:2.0.4"
+  checksum: a25d7589ee65c94d31464c16b72a9dc81dfa0bea9d3e105ae03882d616e2a0712a9c101a599ec482d297c3591e16336962878cb3eb1a0a62d5b76d277a890ce7
+  languageName: node
+  linkType: hard
+
+"@types/istanbul-lib-report@npm:*":
+  version: 3.0.1
+  resolution: "@types/istanbul-lib-report@npm:3.0.1"
+  dependencies:
+    "@types/istanbul-lib-coverage": "*"
+  checksum: cfc66de48577bb7b2636a6afded7056483693c3ea70916276518cdfaa0d4b51bf564ded88fb13e75716665c3af3d4d54e9c2de042c0219dcabad7e81c398688b
+  languageName: node
+  linkType: hard
+
+"@types/istanbul-reports@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "@types/istanbul-reports@npm:3.0.2"
+  dependencies:
+    "@types/istanbul-lib-report": "*"
+  checksum: f52028d6fe4d28f0085dd7ed66ccfa6af632579e9a4091b90928ffef93d4dbec0bacd49e9caf1b939d05df9eafc5ac1f5939413cdf8ac59fbe4b29602d4d0939
+  languageName: node
+  linkType: hard
+
 "@types/json-schema@npm:^7.0.12":
   version: 7.0.13
   resolution: "@types/json-schema@npm:7.0.13"
@@ -1801,6 +1916,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/testing-library__cypress@npm:^5.0.10":
+  version: 5.0.10
+  resolution: "@types/testing-library__cypress@npm:5.0.10"
+  dependencies:
+    "@testing-library/dom": ^7.11.0
+    cypress: "*"
+  checksum: fdcf8adeab8909e95a81cdcf9fd2513bbb6341537948227413f7509ec13c20f8b72f9c9982e530d7da17b2fea50e11257f8f0afa05a1f258483a8a42beda1c11
+  languageName: node
+  linkType: hard
+
 "@types/uuid@npm:8.3.4":
   version: 8.3.4
   resolution: "@types/uuid@npm:8.3.4"
@@ -1812,6 +1937,22 @@ __metadata:
   version: 9.0.1
   resolution: "@types/uuid@npm:9.0.1"
   checksum: c472b8a77cbeded4bc529220b8611afa39bd64677f507838f8083d8aac8033b1f88cb9ddaa2f8589e0dcd2317291d0f6e1379f82d5ceebd6f74f3b4825288e00
+  languageName: node
+  linkType: hard
+
+"@types/yargs-parser@npm:*":
+  version: 21.0.1
+  resolution: "@types/yargs-parser@npm:21.0.1"
+  checksum: 64e6316c2045e2d460c4fb79572f872f9d2f98fddc6d9d3949c71f0b6ad0ef8a2706cf49db26dfb02a9cb81433abb8f340f015e1d20a9692279abe9477b72c8e
+  languageName: node
+  linkType: hard
+
+"@types/yargs@npm:^15.0.0":
+  version: 15.0.16
+  resolution: "@types/yargs@npm:15.0.16"
+  dependencies:
+    "@types/yargs-parser": "*"
+  checksum: 394297641d37f450529279fc375af9cdc70465d28363d62efff2854b7c0d4927e1bf946da027f74463e926571c7d3ded4fc76e79f911b13e9f9afd7a19c0a703
   languageName: node
   linkType: hard
 
@@ -2222,7 +2363,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-regex@npm:^5.0.1":
+"ansi-regex@npm:^5.0.0, ansi-regex@npm:^5.0.1":
   version: 5.0.1
   resolution: "ansi-regex@npm:5.0.1"
   checksum: 2aa4bb54caf2d622f1afdad09441695af2a83aa3fe8b8afa581d205e57ed4261c183c4d3877cee25794443fde5876417d859c108078ab788d6af7e4fe52eb66b
@@ -2384,6 +2525,25 @@ __metadata:
   version: 2.0.1
   resolution: "argparse@npm:2.0.1"
   checksum: 83644b56493e89a254bae05702abf3a1101b4fa4d0ca31df1c9985275a5a5bd47b3c27b7fa0b71098d41114d8ca000e6ed90cad764b306f8a503665e4d517ced
+  languageName: node
+  linkType: hard
+
+"aria-query@npm:5.1.3":
+  version: 5.1.3
+  resolution: "aria-query@npm:5.1.3"
+  dependencies:
+    deep-equal: ^2.0.5
+  checksum: 929ff95f02857b650fb4cbcd2f41072eee2f46159a6605ea03bf63aa572e35ffdff43d69e815ddc462e16e07de8faba3978afc2813650b4448ee18c9895d982b
+  languageName: node
+  linkType: hard
+
+"aria-query@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "aria-query@npm:4.2.2"
+  dependencies:
+    "@babel/runtime": ^7.10.2
+    "@babel/runtime-corejs3": ^7.10.2
+  checksum: 38401a9a400f26f3dcc24b84997461a16b32869a9893d323602bed8da40a8bcc0243b8d2880e942249a1496cea7a7de769e93d21c0baa439f01e1ee936fed665
   languageName: node
   linkType: hard
 
@@ -3135,6 +3295,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"core-js-pure@npm:^3.30.2":
+  version: 3.33.0
+  resolution: "core-js-pure@npm:3.33.0"
+  checksum: d47084a4de9a0cef9779eccd3ac9f435cf9fd7aa71794150cd4c6b305036bcc392d94766d4a7b6456bdd08faba7752d55c2ec40185bda161c3563081c9fa1e17
+  languageName: node
+  linkType: hard
+
 "core-util-is@npm:1.0.2":
   version: 1.0.2
   resolution: "core-util-is@npm:1.0.2"
@@ -3447,6 +3614,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"deep-equal@npm:^2.0.5":
+  version: 2.2.2
+  resolution: "deep-equal@npm:2.2.2"
+  dependencies:
+    array-buffer-byte-length: ^1.0.0
+    call-bind: ^1.0.2
+    es-get-iterator: ^1.1.3
+    get-intrinsic: ^1.2.1
+    is-arguments: ^1.1.1
+    is-array-buffer: ^3.0.2
+    is-date-object: ^1.0.5
+    is-regex: ^1.1.4
+    is-shared-array-buffer: ^1.0.2
+    isarray: ^2.0.5
+    object-is: ^1.1.5
+    object-keys: ^1.1.1
+    object.assign: ^4.1.4
+    regexp.prototype.flags: ^1.5.0
+    side-channel: ^1.0.4
+    which-boxed-primitive: ^1.0.2
+    which-collection: ^1.0.1
+    which-typed-array: ^1.1.9
+  checksum: eb61c35157b6ecb96a5359b507b083fbff8ddb4c86a78a781ee38485f77a667465e45d63ee2ebd8a00e86d94c80e499906900cd82c2debb400237e1662cd5397
+  languageName: node
+  linkType: hard
+
 "deep-is@npm:^0.1.3":
   version: 0.1.4
   resolution: "deep-is@npm:0.1.4"
@@ -3540,6 +3733,13 @@ __metadata:
   dependencies:
     esutils: ^2.0.2
   checksum: fd7673ca77fe26cd5cba38d816bc72d641f500f1f9b25b83e8ce28827fe2da7ad583a8da26ab6af85f834138cf8dae9f69b0cd6ab925f52ddab1754db44d99ce
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.5.6, dom-accessibility-api@npm:^0.5.9":
+  version: 0.5.16
+  resolution: "dom-accessibility-api@npm:0.5.16"
+  checksum: 005eb283caef57fc1adec4d5df4dd49189b628f2f575af45decb210e04d634459e3f1ee64f18b41e2dcf200c844bc1d9279d80807e686a30d69a4756151ad248
   languageName: node
   linkType: hard
 
@@ -3692,6 +3892,23 @@ __metadata:
     unbox-primitive: ^1.0.2
     which-typed-array: ^1.1.11
   checksum: cc70e592d360d7d729859013dee7a610c6b27ed8630df0547c16b0d16d9fe6505a70ee14d1af08d970fdd132b3f88c9ca7815ce72c9011608abf8ab0e55fc515
+  languageName: node
+  linkType: hard
+
+"es-get-iterator@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "es-get-iterator@npm:1.1.3"
+  dependencies:
+    call-bind: ^1.0.2
+    get-intrinsic: ^1.1.3
+    has-symbols: ^1.0.3
+    is-arguments: ^1.1.1
+    is-map: ^2.0.2
+    is-set: ^2.0.2
+    is-string: ^1.0.7
+    isarray: ^2.0.5
+    stop-iteration-iterator: ^1.0.0
+  checksum: 8fa118da42667a01a7c7529f8a8cca514feeff243feec1ce0bb73baaa3514560bd09d2b3438873cf8a5aaec5d52da248131de153b28e2638a061b6e4df13267d
   languageName: node
   linkType: hard
 
@@ -5261,7 +5478,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"internal-slot@npm:^1.0.5":
+"internal-slot@npm:^1.0.4, internal-slot@npm:^1.0.5":
   version: 1.0.5
   resolution: "internal-slot@npm:1.0.5"
   dependencies:
@@ -5290,6 +5507,16 @@ __metadata:
   version: 1.9.1
   resolution: "ipaddr.js@npm:1.9.1"
   checksum: f88d3825981486f5a1942414c8d77dd6674dd71c065adcfa46f578d677edcb99fda25af42675cb59db492fdf427b34a5abfcde3982da11a8fd83a500b41cfe77
+  languageName: node
+  linkType: hard
+
+"is-arguments@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "is-arguments@npm:1.1.1"
+  dependencies:
+    call-bind: ^1.0.2
+    has-tostringtag: ^1.0.0
+  checksum: 7f02700ec2171b691ef3e4d0e3e6c0ba408e8434368504bb593d0d7c891c0dbfda6d19d30808b904a6cb1929bca648c061ba438c39f296c2a8ca083229c49f27
   languageName: node
   linkType: hard
 
@@ -5366,7 +5593,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-date-object@npm:^1.0.1":
+"is-date-object@npm:^1.0.1, is-date-object@npm:^1.0.5":
   version: 1.0.5
   resolution: "is-date-object@npm:1.0.5"
   dependencies:
@@ -5424,6 +5651,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-map@npm:^2.0.1, is-map@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "is-map@npm:2.0.2"
+  checksum: ace3d0ecd667bbdefdb1852de601268f67f2db725624b1958f279316e13fecb8fa7df91fd60f690d7417b4ec180712f5a7ee967008e27c65cfd475cc84337728
+  languageName: node
+  linkType: hard
+
 "is-negative-zero@npm:^2.0.2":
   version: 2.0.2
   resolution: "is-negative-zero@npm:2.0.2"
@@ -5468,6 +5702,13 @@ __metadata:
     call-bind: ^1.0.2
     has-tostringtag: ^1.0.0
   checksum: 362399b33535bc8f386d96c45c9feb04cf7f8b41c182f54174c1a45c9abbbe5e31290bbad09a458583ff6bf3b2048672cdb1881b13289569a7c548370856a652
+  languageName: node
+  linkType: hard
+
+"is-set@npm:^2.0.1, is-set@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "is-set@npm:2.0.2"
+  checksum: b64343faf45e9387b97a6fd32be632ee7b269bd8183701f3b3f5b71a7cf00d04450ed8669d0bd08753e08b968beda96fca73a10fd0ff56a32603f64deba55a57
   languageName: node
   linkType: hard
 
@@ -5528,12 +5769,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-weakmap@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "is-weakmap@npm:2.0.1"
+  checksum: 1222bb7e90c32bdb949226e66d26cb7bce12e1e28e3e1b40bfa6b390ba3e08192a8664a703dff2a00a84825f4e022f9cd58c4599ff9981ab72b1d69479f4f7f6
+  languageName: node
+  linkType: hard
+
 "is-weakref@npm:^1.0.2":
   version: 1.0.2
   resolution: "is-weakref@npm:1.0.2"
   dependencies:
     call-bind: ^1.0.2
   checksum: 95bd9a57cdcb58c63b1c401c60a474b0f45b94719c30f548c891860f051bc2231575c290a6b420c6bc6e7ed99459d424c652bd5bf9a1d5259505dc35b4bf83de
+  languageName: node
+  linkType: hard
+
+"is-weakset@npm:^2.0.1":
+  version: 2.0.2
+  resolution: "is-weakset@npm:2.0.2"
+  dependencies:
+    call-bind: ^1.0.2
+    get-intrinsic: ^1.1.1
+  checksum: 5d8698d1fa599a0635d7ca85be9c26d547b317ed8fd83fc75f03efbe75d50001b5eececb1e9971de85fcde84f69ae6f8346bc92d20d55d46201d328e4c74a367
   languageName: node
   linkType: hard
 
@@ -6010,6 +6268,15 @@ __metadata:
   version: 3.2.1
   resolution: "luxon@npm:3.2.1"
   checksum: 3fa3def2c5f5d3032b4c46220c4da8aeb467ac979888fc9d2557adcd22195f93516b4ad5909a75862bec8dc6ddc0953b0f38e6d2f4a8ab8450ddc531a83cf20d
+  languageName: node
+  linkType: hard
+
+"lz-string@npm:^1.4.4, lz-string@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "lz-string@npm:1.5.0"
+  bin:
+    lz-string: bin/bin.js
+  checksum: 1ee98b4580246fd90dd54da6e346fb1caefcf05f677c686d9af237a157fdea3fd7c83a4bc58f858cd5b10a34d27afe0fdcbd0505a47e0590726a873dc8b8f65d
   languageName: node
   linkType: hard
 
@@ -6522,6 +6789,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"object-is@npm:^1.1.5":
+  version: 1.1.5
+  resolution: "object-is@npm:1.1.5"
+  dependencies:
+    call-bind: ^1.0.2
+    define-properties: ^1.1.3
+  checksum: 989b18c4cba258a6b74dc1d74a41805c1a1425bce29f6cabb50dcb1a6a651ea9104a1b07046739a49a5bb1bc49727bcb00efd5c55f932f6ea04ec8927a7901fe
+  languageName: node
+  linkType: hard
+
 "object-keys@npm:^1.1.1":
   version: 1.1.1
   resolution: "object-keys@npm:1.1.1"
@@ -6920,6 +7197,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pretty-format@npm:^26.6.2":
+  version: 26.6.2
+  resolution: "pretty-format@npm:26.6.2"
+  dependencies:
+    "@jest/types": ^26.6.2
+    ansi-regex: ^5.0.0
+    ansi-styles: ^4.0.0
+    react-is: ^17.0.1
+  checksum: e3b808404d7e1519f0df1aa1f25cee0054ab475775c6b2b8c5568ff23194a92d54bf93274139b6f584ca70fd773be4eaa754b0e03f12bb0a8d1426b07f079976
+  languageName: node
+  linkType: hard
+
+"pretty-format@npm:^27.0.2":
+  version: 27.5.1
+  resolution: "pretty-format@npm:27.5.1"
+  dependencies:
+    ansi-regex: ^5.0.1
+    ansi-styles: ^5.0.0
+    react-is: ^17.0.1
+  checksum: cf610cffcb793885d16f184a62162f2dd0df31642d9a18edf4ca298e909a8fe80bdbf556d5c9573992c102ce8bf948691da91bf9739bee0ffb6e79c8a8a6e088
+  languageName: node
+  linkType: hard
+
 "pretty-format@npm:^29.5.0":
   version: 29.7.0
   resolution: "pretty-format@npm:29.7.0"
@@ -7063,6 +7363,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-is@npm:^17.0.1":
+  version: 17.0.2
+  resolution: "react-is@npm:17.0.2"
+  checksum: 9d6d111d8990dc98bc5402c1266a808b0459b5d54830bbea24c12d908b536df7883f268a7868cfaedde3dd9d4e0d574db456f84d2e6df9c4526f99bb4b5344d8
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^18.0.0":
   version: 18.2.0
   resolution: "react-is@npm:18.2.0"
@@ -7151,7 +7458,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regexp.prototype.flags@npm:^1.5.1":
+"regexp.prototype.flags@npm:^1.5.0, regexp.prototype.flags@npm:^1.5.1":
   version: 1.5.1
   resolution: "regexp.prototype.flags@npm:1.5.1"
   dependencies:
@@ -7728,6 +8035,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stop-iteration-iterator@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "stop-iteration-iterator@npm:1.0.0"
+  dependencies:
+    internal-slot: ^1.0.4
+  checksum: d04173690b2efa40e24ab70e5e51a3ff31d56d699550cfad084104ab3381390daccb36652b25755e420245f3b0737de66c1879eaa2a8d4fc0a78f9bf892fcb42
+  languageName: node
+  linkType: hard
+
 "string-argv@npm:^0.3.1":
   version: 0.3.2
   resolution: "string-argv@npm:0.3.2"
@@ -7965,10 +8281,12 @@ __metadata:
   dependencies:
     "@badeball/cypress-cucumber-preprocessor": ^18.0.6
     "@bahmutov/cypress-esbuild-preprocessor": ^2.2.0
+    "@testing-library/cypress": ^10.0.1
     "@types/command-line-args": ^5.2.1
     "@types/cypress": ^1.1.3
     "@types/node": ^20.8.2
     "@types/resolve": ^1.20.3
+    "@types/testing-library__cypress": ^5.0.10
     "@vitest/coverage-istanbul": ^0.34.6
     cypress: ^13.3.0
     esbuild: ^0.19.4
@@ -8694,7 +9012,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which-typed-array@npm:^1.1.11":
+"which-collection@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "which-collection@npm:1.0.1"
+  dependencies:
+    is-map: ^2.0.1
+    is-set: ^2.0.1
+    is-weakmap: ^2.0.1
+    is-weakset: ^2.0.1
+  checksum: c815bbd163107ef9cb84f135e6f34453eaf4cca994e7ba85ddb0d27cea724c623fae2a473ceccfd5549c53cc65a5d82692de418166df3f858e1e5dc60818581c
+  languageName: node
+  linkType: hard
+
+"which-typed-array@npm:^1.1.11, which-typed-array@npm:^1.1.9":
   version: 1.1.11
   resolution: "which-typed-array@npm:1.1.11"
   dependencies:


### PR DESCRIPTION
Update smoke tests.

- Use cypress-testing-library for cleaner selectors
- Remove ids from dom
- Condense smoke tests to one test so it's not constantly refreshing the page and potentially slamming the USDA api