### PR TITLE
Fix bug in Week generator. date-fns expects a date and not a year for…

### DIFF
--- a/lib/Repository.ts
+++ b/lib/Repository.ts
@@ -64,8 +64,8 @@ class Repository<T extends MprObservation> {
             return;
         }
 
-        const start = data[0].reportDate;
-        const end = data[data.length - 1].reportDate;
+        const { reportDate: start } = data[0];
+        const { reportDate: end } = data[data.length - 1];
         const dates = new Set(map(data, record => record.reportDate.getTime()));
 
         const cached = filter(flatten(map(Week.with(start, end), week =>

--- a/lib/cutout/PrimalViewModel.ts
+++ b/lib/cutout/PrimalViewModel.ts
@@ -29,14 +29,14 @@ class PrimalViewModel {
 
     private constructor(primal: Primal, series: Series[]) {
         const date = today();
-        this.#primal = primal;
-        this.#series = series;
 
         const stats = Primals.map((label, index) => ({
             ...Stat.from(label, Series.find(series[index], date).value),
-            selected: Primals[index] === this.#primal
+            selected: Primals[index] === primal
         }));
 
+        this.#primal = primal;
+        this.#series = series;
         this.stats = new ObservableState(stats);
         this.selected = new ObservableState(Series.find(this.series, date));
     }

--- a/lib/time/Week.ts
+++ b/lib/time/Week.ts
@@ -14,7 +14,7 @@ function* iterateWeeks(start: Week, end: Week): Iterator<Week> {
 
     for (let year = startYear; year <= endYear; year++) {
         const firstWeek = year === startYear ? startWeek : 1;
-        const lastWeek = year === endYear ? endWeek : getISOWeeksInYear(year);
+        const lastWeek = year === endYear ? endWeek : getISOWeeksInYear(new Date(year, 1, 1));
 
         for (let week = firstWeek; week <= lastWeek; week++) {
             yield new Week(year, week);

--- a/test/lib/Repository.spec.ts
+++ b/test/lib/Repository.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi, it } from "vitest";
 import { today } from "lib/time";
 import dates from "lib/time/dates";
 import Repository from "lib/Repository";
@@ -44,21 +44,21 @@ describe("Repository caching", () => {
         expect(fetch).toHaveBeenCalledWith(new Date(2021, 11, 20), new Date(2021, 11, 23));
     });
 
-    test("fetch missing data", async () => {
+    it("fetches missing data", async () => {
         const result = await repository.query(new Date(2021, 11, 16), new Date(2021, 11, 23));
         expect(fetch).toHaveBeenCalledWith(new Date(2021, 11, 23), new Date(2021, 11, 23));
         expect(result.length).toBe(7);
         expect(fetch).toHaveBeenCalledTimes(1);
     });
 
-    test("don't request data from the future", async () => {
+    it("doesn't request data from the future", async () => {
         const result = await repository.query(new Date(2022, 1, 1), new Date(2021, 1, 8));
         expect(result.length).toBe(0);
         expect(fetch).not.toHaveBeenCalled();
     });
 });
 
-test("don't cache empty results", async () => {
+it("doesn't cache empty results", async () => {
     const fetch = vi.fn(() => Promise.resolve([]));
     const repository = new Repository(fetch);
 


### PR DESCRIPTION
There was a bug in the ISOWeek generator, where it was using date-fns `getISOWeeksInYear` and passing it a year, when the function actually expects a `Date`. So it was always returning the number of weeks for the year 1970, which is 53 weeks (and most years have 52). This was causing an issue with not caching weeks on year boundaries. 